### PR TITLE
Hal/fix 38 support

### DIFF
--- a/meltano.yml
+++ b/meltano.yml
@@ -29,7 +29,25 @@ plugins:
     - name: start_date
       kind: string
     select:
-      - reviews
+      # uncomment as necessary
+      # - reviews.*
+      # - stats_by_dimension_buyers_7d.*
+      # - stats_by_dimension_crashes.*
+      # - stats_by_dimension_gcm.*
+      - stats_by_dimension_installs.*
+      # - stats_by_dimension_ratings.*
+      # - stats_by_dimension_retained_installers.*
+      # - stats_overview_crashes.*
+      # - stats_overview_gcm.*
+      - stats_overview_installs.*
+      # - stats_overview_ratings.*
+      # - store_performance_country.*
+      # - store_performance_traffic_source.*
+      # - subscriptions_country.*
+      - earnings.*
+      # - play_balance_krw.*
+      # - sales_reports.*
+
   loaders:
   - name: target-jsonl
     variant: andyh1203

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-playstore"
-version = "0.1.3"
+version = "0.1.4"
 description = "`tap-playstore` is a Singer tap for Google PlayStore Console Reports, built with the Meltano Singer SDK."
 readme = "README.md"
 authors = ["Haleemur Ali <haleemur@gmail.com>"]

--- a/tap_playstore/client.py
+++ b/tap_playstore/client.py
@@ -52,7 +52,9 @@ class PlayStoreStream(Stream):
         }
         for i, row in enumerate(reader):
             static_["_file_lineno"] = i
-            yield self.convert_types(dict(zip(fields, row)), typemap) | static_
+            rec = self.convert_types(dict(zip(fields, row)), typemap)
+            # use {**rec, **static_} instead of rec | static for py3.8 support
+            yield {**rec, **static_}
 
     def convert_types(self, row: dict[str, Any], typemap: dict) -> dict[str, Any]:
         """Convert string values read from the CSV files."""


### PR DESCRIPTION
# Summary

* avoids use of `dict1 | dict2` in favour of `{**dict1, **dict2}` to support python 3.8